### PR TITLE
Ignore errors when killing PM2 processes

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -112,5 +112,6 @@
 - name: Cleanup pm2 processes  # HACK: this should not be happening
   shell:
     ps aux | grep PM2 | grep -v grep | awk '{print $2}' | xargs kill -9  # noqa 306
+  ignore_errors: true
   tags:
     - molecule-idempotence-notest  # noqa 301


### PR DESCRIPTION
When there is no PM2 process to kill the script fails