### PR TITLE
Ignore errors if there is no PM2 service already running

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -112,5 +112,6 @@
 - name: Cleanup pm2 processes  # HACK: this should not be happening
   shell:
     ps aux | grep PM2 | grep -v grep | awk '{print $2}' | xargs kill -9  # noqa 306
+  ignore_errors: true
   tags:
     - molecule-idempotence-notest  # noqa 301


### PR DESCRIPTION
The help for kill is printed in the event there are no PM2 processess.
This tends to happen when running the playbook a couple of times and
encounter errors after this task, the next run is very likely the PM2
process will not be running.

    ps aux | grep PM2 | grep -v grep | awk '{print $2}' | xargs kill -9

    Usage:
     kill [options] <pid> [...]

    Options:
     <pid> [...]            send signal to every <pid> listed
     -<signal>, -s, --signal <signal>
                            specify the <signal> to be sent
     -l, --list=[<signal>]  list all signal names, or convert one to a name
     -L, --table            list all signal names in a nice table

     -h, --help     display this help and exit
     -V, --version  output version information and exit

    For more details see kill(1).