### PR TITLE
Affected Issue(s): Fix latest "express-versioned"

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,16 @@
 ---
+# creates a sym-link express_codebase_path; that points to the express checkout path
+- name: Make the new codebase current
+  file:
+    src: "{{ express_checkout_path }}"
+    dest: "{{ express_codebase_path }}"
+    state: link
+    force: true
+    owner: "{{ express_system_user }}"
+    group: "{{ express_system_group }}"
+  tags:
+    - molecule-idempotence-notest
+
 - name: Copy environment variables file
   template:
     src: env.j2
@@ -29,18 +41,6 @@
   tags:
     - molecule-idempotence-notest  # noqa 301
 
-# creates a sym-link express_codebase_path; that points to the express checkout path
-- name: Make the new codebase current
-  file:
-    src: "{{ express_checkout_path }}"
-    dest: "{{ express_codebase_path }}"
-    state: link
-    force: true
-    owner: "{{ express_system_user }}"
-    group: "{{ express_system_group }}"
-  tags:
-    - molecule-idempotence-notest
-
 - name: Restart express pm2 process
   become: true
   become_user: "{{ express_system_user }}"
@@ -51,7 +51,7 @@
   ignore_errors: true
   changed_when: false
 
-- name: set express_service_exists fact
+- name: set express_service_not_exists fact
   set_fact:
     express_service_not_exists: "{{ pm2_process.rc != 0 }}"
 
@@ -71,7 +71,7 @@
       become: true
       become_user: "{{ express_system_user }}"
       command: >
-        {{ express_pm2_path }} start dist/index.js
+        {{ express_pm2_path }} start {{ express_codebase_path }}/dist/index.js
         --name {{ express_service_name }}
       args:
         chdir: "{{ express_app_path }}"


### PR DESCRIPTION
### Before
![image](https://user-images.githubusercontent.com/78334846/167562204-ef98511b-d0b2-42f2-a558-7c08b5ca5b0c.png)

### After
![image](https://user-images.githubusercontent.com/78334846/167562540-a7c3ac13-6c85-41ce-a674-919c7fe7c3a6.png)

https://www.notion.so/DevOps-Fix-ansible-express-role-so-the-service-restarts-with-the-latest-express-versioned-7dedbb6f4a2748f993c6e4b534b3bcbd

What this commit has achieved:
1. Previously the service showed `pm2[460133]: [PM2] Process /home/react/express-versioned/${ANSIBLE_DATE_TIME_EPOCH}/dist/index.js restored` in its status log, after this changes it is now `pm2[463199]: [PM2] Process /home/react/express/dist/index.js restored` with `/home/react/express` is symlink to latest `/home/react/express-versioned/${ANSIBLE_DATE_TIME_EPOCH}`